### PR TITLE
Fixed terraform installation

### DIFF
--- a/dependencies/action.yml
+++ b/dependencies/action.yml
@@ -48,25 +48,29 @@ runs:
       shell: bash
       run: |
         set -ex
-        curl -fsSL https://apt.releases.hashicorp.com/gpg | sudo apt-key add -
-        sudo apt-add-repository "deb [arch=$(dpkg --print-architecture)] https://apt.releases.hashicorp.com $(lsb_release -cs) main"
-        sudo apt install -y terraform
+        if ! which terraform 2>/dev/null; then
+          curl -fsSL https://apt.releases.hashicorp.com/gpg | sudo apt-key add -
+          sudo apt-add-repository "deb [arch=$(dpkg --print-architecture)] https://apt.releases.hashicorp.com $(lsb_release -cs) main"
+          sudo apt install -y terraform
+        fi
     - if: ${{ inputs.docker && inputs.docker != 'false' }}
       name: Install Docker
       shell: bash
       run: |
         set -ex
-        curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
-        echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
-        sudo apt-get update
-        sudo apt-get install -y docker-ce docker-ce-cli containerd.io
+        if ! which docker 2>/dev/null; then
+          curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
+          echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+          sudo apt-get update
+          sudo apt-get install -y docker-ce docker-ce-cli containerd.io
 
-        sudo groupadd -f docker
-        sudo usermod -aG docker "$USER"
-        newgrp docker
+          sudo groupadd -f docker
+          sudo usermod -aG docker "$USER"
+          newgrp docker
 
-        sudo systemctl enable docker.service
-        sudo systemctl enable containerd.service
+          sudo systemctl enable docker.service
+          sudo systemctl enable containerd.service
+        fi
 
         docker run hello-world
         


### PR DESCRIPTION
Terraform is now included in the latest version of the ubuntu image. This makes the installation of terraform and docker effective only if it is not already installed.