### PR TITLE
Add working directory option

### DIFF
--- a/deploy/action.yml
+++ b/deploy/action.yml
@@ -39,7 +39,7 @@ inputs:
   working-directory:
     descriptiont: "Working directory (should be the ArmoniK repo root folder)"
     required: false
-    default: $GITHUB_WORKSPACE
+    default: ${{ github.workspace }}
 outputs:
   terraform-output:
     description: "Terraform output of the deployment"

--- a/deploy/action.yml
+++ b/deploy/action.yml
@@ -44,6 +44,9 @@ outputs:
   terraform-output:
     description: "Terraform output of the deployment"
     value: ${{ steps.apply.outputs.terraform-output }}
+  generated-folder:
+    description: "Generated folder"
+    value: ${{ steps.apply.outputs.generated-folder }}
 runs:
   using: composite
   steps:
@@ -111,6 +114,8 @@ runs:
           echo
           echo __GITHUB_EOF__
         } >> "$GITHUB_OUTPUT"
+        cd generated
+        echo "generated-folder=$(pwd)" >> "$GITHUB_OUTPUT"
     - name: Terraform output
       uses: actions/upload-artifact@v3
       with:

--- a/deploy/action.yml
+++ b/deploy/action.yml
@@ -46,13 +46,11 @@ outputs:
     value: ${{ steps.apply.outputs.terraform-output }}
 runs:
   using: composite
-  defaults:
-    run:
-      working-directory: ${{ inputs.working-directory }}
   steps:
     - id: patch
       name: Patch versions
       shell: bash
+      working-directory: ${{ inputs.working-directory }}
       env:
         CORE_VERSION: ${{ inputs.core-version }}
         GUI_VERSION: ${{ inputs.gui-version }}
@@ -74,6 +72,7 @@ runs:
     - id: options
       name: Patch options
       shell: bash
+      working-directory: ${{ inputs.working-directory }}
       env:
         TLS: ${{ inputs.tls }}
         MTLS: ${{ inputs.mtls }}
@@ -96,6 +95,7 @@ runs:
     - id: apply
       name: Apply
       shell: bash
+      working-directory: ${{ inputs.working-directory }}
       env:
         INPUT_TYPE: ${{ inputs.type }}
         INPUT_PREFIX: ${{ inputs.prefix }}
@@ -116,11 +116,11 @@ runs:
       with:
         name: terraform-output
         path: |
-          infrastructure/quick-deploy/${{ inputs.type }}/generated
-          !infrastructure/quick-deploy/${{ inputs.type }}/generated/modules
-          !infrastructure/quick-deploy/${{ inputs.type }}/generated/providers
-          !infrastructure/quick-deploy/${{ inputs.type }}/generated/.prefix
-          infrastructure/quick-deploy/${{ inputs.type }}/all/generated
-          !infrastructure/quick-deploy/${{ inputs.type }}/all/generated/modules
-          !infrastructure/quick-deploy/${{ inputs.type }}/all/generated/providers
-          !infrastructure/quick-deploy/${{ inputs.type }}/all/generated/.prefix
+          ${{ inputs.working-directory }}/infrastructure/quick-deploy/${{ inputs.type }}/generated
+          !${{ inputs.working-directory }}/infrastructure/quick-deploy/${{ inputs.type }}/generated/modules
+          !${{ inputs.working-directory }}/infrastructure/quick-deploy/${{ inputs.type }}/generated/providers
+          !${{ inputs.working-directory }}/infrastructure/quick-deploy/${{ inputs.type }}/generated/.prefix
+          ${{ inputs.working-directory }}/infrastructure/quick-deploy/${{ inputs.type }}/all/generated
+          !${{ inputs.working-directory }}/infrastructure/quick-deploy/${{ inputs.type }}/all/generated/modules
+          !${{ inputs.working-directory }}/infrastructure/quick-deploy/${{ inputs.type }}/all/generated/providers
+          !${{ inputs.working-directory }}/infrastructure/quick-deploy/${{ inputs.type }}/all/generated/.prefix

--- a/deploy/action.yml
+++ b/deploy/action.yml
@@ -36,12 +36,19 @@ inputs:
     description: "Path to custom client certificate authority"
     required: false
     default: ""
+  working-directory:
+    descriptiont: "Working directory (should be the ArmoniK repo root folder)"
+    required: false
+    default: $GITHUB_WORKSPACE
 outputs:
   terraform-output:
     description: "Terraform output of the deployment"
     value: ${{ steps.apply.outputs.terraform-output }}
 runs:
   using: composite
+  defaults:
+    run:
+      working-directory: ${{ inputs.working-directory }}
   steps:
     - id: patch
       name: Patch versions

--- a/destroy/action.yml
+++ b/destroy/action.yml
@@ -15,12 +15,10 @@ inputs:
 
 runs:
   using: composite
-  defaults:
-    run:
-      working-directory: ${{ inputs.working-directory }}
   steps:
     - id: destroy
       name: Destroy
+      working-directory: ${{ inputs.working-directory }}
       shell: bash
       env:
         INPUT_TYPE: ${{ inputs.type }}

--- a/destroy/action.yml
+++ b/destroy/action.yml
@@ -11,7 +11,7 @@ inputs:
   working-directory:
     descriptiont: "Working directory (should be the ArmoniK repo root folder)"
     required: false
-    default: $GITHUB_WORKSPACE
+    default: ${{ github.workspace }}
 
 runs:
   using: composite

--- a/destroy/action.yml
+++ b/destroy/action.yml
@@ -8,9 +8,16 @@ inputs:
     description: "Prefix for the deployment"
     required: false
     default: "armonik-cicd"
+  working-directory:
+    descriptiont: "Working directory (should be the ArmoniK repo root folder)"
+    required: false
+    default: $GITHUB_WORKSPACE
 
 runs:
   using: composite
+  defaults:
+    run:
+      working-directory: ${{ inputs.working-directory }}
   steps:
     - id: destroy
       name: Destroy


### PR DESCRIPTION
When executing the action, it assumes the infrastructure is the checked out ref. This PR aims at adding the directory where the infrastructure is located as an argument in order to allow having the infra located elsewhere.