### PR TITLE
fix: ignore heavy .git folder in artifact uploading

### DIFF
--- a/deploy/action.yml
+++ b/deploy/action.yml
@@ -125,6 +125,7 @@ runs:
           !${{ inputs.working-directory }}/infrastructure/quick-deploy/${{ inputs.type }}/generated/modules
           !${{ inputs.working-directory }}/infrastructure/quick-deploy/${{ inputs.type }}/generated/providers
           !${{ inputs.working-directory }}/infrastructure/quick-deploy/${{ inputs.type }}/generated/.prefix
+          !${{ inputs.working-directory }}/infrastructure/quick-deploy/${{ inputs.type }}/generated/**/.git
           ${{ inputs.working-directory }}/infrastructure/quick-deploy/${{ inputs.type }}/all/generated
           !${{ inputs.working-directory }}/infrastructure/quick-deploy/${{ inputs.type }}/all/generated/modules
           !${{ inputs.working-directory }}/infrastructure/quick-deploy/${{ inputs.type }}/all/generated/providers

--- a/deploy/action.yml
+++ b/deploy/action.yml
@@ -129,3 +129,4 @@ runs:
           !${{ inputs.working-directory }}/infrastructure/quick-deploy/${{ inputs.type }}/all/generated/modules
           !${{ inputs.working-directory }}/infrastructure/quick-deploy/${{ inputs.type }}/all/generated/providers
           !${{ inputs.working-directory }}/infrastructure/quick-deploy/${{ inputs.type }}/all/generated/.prefix
+          !${{ inputs.working-directory }}/infrastructure/quick-deploy/${{ inputs.type }}/all/generated/**/.git


### PR DESCRIPTION
Need to ignore .git folder inside generated folder to avoid heavy upload artifact