### PR TITLE
fix: Support for all or all-in-one folder

### DIFF
--- a/bootstrap-deploy/action.yml
+++ b/bootstrap-deploy/action.yml
@@ -23,5 +23,10 @@ runs:
         set -ex
         cd infrastructure/quick-deploy/
         cd "$INPUT_TYPE"
-        [ ! -e all-in-one ] || cd all-in-one
+
+        if [ ! -e all-in-one ]; then
+          cd all-in-one
+        elif [ ! -e all ]; then
+          cd all
+        fi
         make PREFIX="$INPUT_PREFIX" bootstrap-deploy

--- a/bootstrap-destroy/action.yml
+++ b/bootstrap-destroy/action.yml
@@ -23,5 +23,10 @@ runs:
         set -ex
         cd infrastructure/quick-deploy/
         cd "$INPUT_TYPE"
-        [ ! -e all-in-one ] || cd all-in-one
+
+        if [ ! -e all-in-one ]; then
+          cd all-in-one
+        elif [ ! -e all ]; then
+          cd all
+        fi
         make PREFIX="$INPUT_PREFIX" bootstrap-destroy

--- a/deploy/action.yml
+++ b/deploy/action.yml
@@ -106,7 +106,12 @@ runs:
         set -ex
         cd infrastructure/quick-deploy/
         cd "$INPUT_TYPE"
-        [ ! -e all-in-one ] || cd all-in-one
+
+        if [ ! -e all-in-one ]; then
+          cd all-in-one
+        elif [ ! -e all ]; then
+          cd all
+        fi
         make PREFIX="$INPUT_PREFIX" deploy
         {
           echo 'terraform-output<<__GITHUB_EOF__'
@@ -126,7 +131,12 @@ runs:
           !${{ inputs.working-directory }}/infrastructure/quick-deploy/${{ inputs.type }}/generated/providers
           !${{ inputs.working-directory }}/infrastructure/quick-deploy/${{ inputs.type }}/generated/.prefix
           !${{ inputs.working-directory }}/infrastructure/quick-deploy/${{ inputs.type }}/generated/**/.git
-          ${{ inputs.working-directory }}/infrastructure/quick-deploy/${{ inputs.type }}/all-in-one/generated
+          ${{ inputs.working-directory }}/infrastructure/quick-deploy/${{ inputs.type }}/all/generated
+          !${{ inputs.working-directory }}/infrastructure/quick-deploy/${{ inputs.type }}/all/generated/modules
+          !${{ inputs.working-directory }}/infrastructure/quick-deploy/${{ inputs.type }}/all/generated/providers
+          !${{ inputs.working-directory }}/infrastructure/quick-deploy/${{ inputs.type }}/all/generated/.prefix
+          !${{ inputs.working-directory }}/infrastructure/quick-deploy/${{ inputs.type }}/all/generated/**/.git
+          ${{ inputs.working-directory }}/infrastructure/quick-deploy/${{ inputs.type }}/all/generated
           !${{ inputs.working-directory }}/infrastructure/quick-deploy/${{ inputs.type }}/all-in-one/generated/modules
           !${{ inputs.working-directory }}/infrastructure/quick-deploy/${{ inputs.type }}/all-in-one/generated/providers
           !${{ inputs.working-directory }}/infrastructure/quick-deploy/${{ inputs.type }}/all-in-one/generated/.prefix

--- a/destroy/action.yml
+++ b/destroy/action.yml
@@ -27,7 +27,12 @@ runs:
         set -ex
         cd infrastructure/quick-deploy/
         cd "$INPUT_TYPE"
-        [ ! -e all-in-one ] || cd all-in-one
+
+        if [ ! -e all-in-one ]; then
+          cd all-in-one
+        elif [ ! -e all ]; then
+          cd all
+        fi
         make PREFIX="$INPUT_PREFIX" init
         make PREFIX="$INPUT_PREFIX" output
         EKS_NAME="$(jq -r .eks.name generated/armonik-output.json)"


### PR DESCRIPTION
#9 removed the support for all folder. This makes it impossible to deploy currently in ArmoniK. This PR makes it compatible with both old `all` folder and new `all-in-one` folder, making the transition smoother.