### PR TITLE
fix: K3s use crictl

### DIFF
--- a/dependencies/action.yml
+++ b/dependencies/action.yml
@@ -91,7 +91,7 @@ runs:
         INSTALL_K3S_VERSION: ${{ inputs.K3S_VERSION }}
       run: |
         set -ex
-        curl -sfL https://get.k3s.io | sh -s - --write-kubeconfig-mode 644 --docker --write-kubeconfig ~/.kube/config
+        curl -sfL https://get.k3s.io | sh -s - --write-kubeconfig-mode 644 --write-kubeconfig ~/.kube/config
         sudo chown runner: -R ~/.kube
     - name: Install Kubectl
       shell: bash


### PR DESCRIPTION
Remove the use of docker for K3s to avoid a bug where `dockerd` would eat CPU and RAM to the point that short jobs would take a very long time to finish.