### PR TITLE
fix: add make get-modules to destroy action

### DIFF
--- a/destroy/action.yml
+++ b/destroy/action.yml
@@ -27,6 +27,7 @@ runs:
         set -ex
         cd infrastructure/quick-deploy/
         cd "$INPUT_TYPE"
+        make PREFIX="$INPUT_PREFIX" get-modules
         make PREFIX="$INPUT_PREFIX" init
         make PREFIX="$INPUT_PREFIX" output
         EKS_NAME="$(jq -r .eks.name generated/armonik-output.json)"


### PR DESCRIPTION
# Motivation

The action fails since Terraform modules are not loaded. This PR aims to fix the job.

# Description

This PR simply adds a `make get-modules` command before the `make init` .

# Testing

This action is callable from https://github.com/aneoconsulting/ArmoniK/actions/workflows/manual-aws-destroy.yml .

# Impact

The action loads the Terraform modules thus fixing the error.

# Additional Information

# Checklist

- [X] My code adheres to the coding and style guidelines of the project.
- [X] I have performed a self-review of my code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have thoroughly tested my modifications and added tests when necessary.
- [ ] Tests pass locally and in the CI.
- [X] I have assessed the performance impact of my modifications.