### PR TITLE
feat: capacity to parametrize TF parameters file at infra deployment and destruction

### DIFF
--- a/deploy/action.yml
+++ b/deploy/action.yml
@@ -37,7 +37,7 @@ inputs:
     required: false
     default: ""
   working-directory:
-    descriptiont: "Working directory (should be the ArmoniK repo root folder)"
+    description: "Working directory (should be the ArmoniK repo root folder)"
     required: false
     default: ${{ github.workspace }}
   shared-data-folder:
@@ -48,6 +48,11 @@ inputs:
     description: "Suffix to append to the terraform output artifact"
     required: false
     default: "default"
+  parameters-file-path:
+    description: "Relative path for the Terraform configuration file, root being the ArmoniK repository. Empty keeps it to the default parameters.tfvars associated with your deployment type"
+    required: false
+    default: ""
+
 outputs:
   terraform-output:
     description: "Terraform output of the deployment"
@@ -115,8 +120,12 @@ runs:
       env:
         INPUT_TYPE: ${{ inputs.type }}
         INPUT_PREFIX: ${{ inputs.prefix }}
+        PARAMETERS_FILE_PATH: ${{ inputs.parameters-file-path }}
       run: |
         set -ex
+        if [ -n "$PARAMETERS_FILE_PATH" ]; then
+          export PARAMETERS_FILE="$(pwd)/$PARAMETERS_FILE_PATH"
+        fi
         cd infrastructure/quick-deploy/
         cd "$INPUT_TYPE"
         make PREFIX="$INPUT_PREFIX" deploy

--- a/destroy/action.yml
+++ b/destroy/action.yml
@@ -12,6 +12,10 @@ inputs:
     description: "Working directory (should be the ArmoniK repo root folder)"
     required: false
     default: ${{ github.workspace }}
+  parameters-file-path:
+    description: "Relative path for the Terraform configuration file, root being the ArmoniK repository. Empty keeps it to the default parameters.tfvars associated with your deployment type"
+    required: false
+    default: ""
 
 runs:
   using: composite
@@ -23,8 +27,12 @@ runs:
       env:
         INPUT_TYPE: ${{ inputs.type }}
         INPUT_PREFIX: ${{ inputs.prefix }}
+        PARAMETERS_FILE_PATH: ${{ inputs.parameters-file-path }}
       run: |
         set -ex
+        if [ -n "$PARAMETERS_FILE_PATH" ]; then
+          export PARAMETERS_FILE="$(pwd)/$PARAMETERS_FILE_PATH"
+        fi
         cd infrastructure/quick-deploy/
         cd "$INPUT_TYPE"
         make PREFIX="$INPUT_PREFIX" get-modules


### PR DESCRIPTION
Linked with ArmoniK benchmarking project, it would be nice to be able to deploy ArmoniK with specific Terraform parameters file instead of being forced to use the default one defined in the Makefile. 

https://github.com/aneoconsulting/ArmoniK/pull/1330 depends on this one.